### PR TITLE
SER-142: Build auth pages (login & registration)

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,31 @@
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="flex min-h-svh flex-col items-center justify-center px-4 py-12"
+      style={{ backgroundColor: "var(--canvas)" }}
+    >
+      <div className="mb-8 flex items-center gap-2">
+        <div
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-sm font-bold"
+          style={{
+            backgroundColor: "var(--brand)",
+            color: "var(--brand-foreground)",
+          }}
+        >
+          B
+        </div>
+        <span
+          className="text-xl font-bold tracking-tight"
+          style={{ color: "var(--ink)" }}
+        >
+          BrokerApp
+        </span>
+      </div>
+      <div className="w-full max-w-sm">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function LoginPage() {
+  const router = useRouter();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    router.push("/dashboard");
+  }
+
+  return (
+    <Card
+      className="border-0"
+      style={{ boxShadow: "var(--shadow-elevated)" }}
+    >
+      <CardHeader className="text-center">
+        <CardTitle
+          className="text-2xl font-bold"
+          style={{ color: "var(--ink)" }}
+        >
+          Welkom terug
+        </CardTitle>
+        <CardDescription style={{ color: "var(--ink-secondary)" }}>
+          Log in op je BrokerApp account
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="email">E-mailadres</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="jan@makelaardij.nl"
+              autoComplete="email"
+              className="bg-[var(--surface-2)]"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="password">Wachtwoord</Label>
+              <Link
+                href="#"
+                className="text-xs font-medium"
+                style={{ color: "var(--brand)" }}
+              >
+                Wachtwoord vergeten?
+              </Link>
+            </div>
+            <Input
+              id="password"
+              type="password"
+              placeholder="********"
+              autoComplete="current-password"
+              className="bg-[var(--surface-2)]"
+            />
+          </div>
+          <Button type="submit" className="w-full">
+            Inloggen
+          </Button>
+          <div className="relative flex items-center gap-4">
+            <div
+              className="h-px flex-1"
+              style={{ backgroundColor: "var(--border-emphasis)" }}
+            />
+            <span
+              className="text-xs"
+              style={{ color: "var(--ink-tertiary)" }}
+            >
+              of
+            </span>
+            <div
+              className="h-px flex-1"
+              style={{ backgroundColor: "var(--border-emphasis)" }}
+            />
+          </div>
+          <Button type="button" variant="outline" className="w-full">
+            <svg
+              className="mr-2 h-4 w-4"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            Inloggen met Google
+          </Button>
+        </form>
+        <p
+          className="mt-6 text-center text-sm"
+          style={{ color: "var(--ink-secondary)" }}
+        >
+          Nog geen account?{" "}
+          <Link
+            href="/registreren"
+            className="font-medium"
+            style={{ color: "var(--brand)" }}
+          >
+            Registreren
+          </Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(auth)/registreren/page.tsx
+++ b/src/app/(auth)/registreren/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function RegistrerenPage() {
+  const router = useRouter();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    router.push("/dashboard");
+  }
+
+  return (
+    <Card
+      className="border-0"
+      style={{ boxShadow: "var(--shadow-elevated)" }}
+    >
+      <CardHeader className="text-center">
+        <CardTitle
+          className="text-2xl font-bold"
+          style={{ color: "var(--ink)" }}
+        >
+          Account aanmaken
+        </CardTitle>
+        <CardDescription style={{ color: "var(--ink-secondary)" }}>
+          Start met het genereren van woningadvertenties
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="name">Volledige naam</Label>
+            <Input
+              id="name"
+              type="text"
+              placeholder="Jan de Vries"
+              autoComplete="name"
+              className="bg-[var(--surface-2)]"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="email">E-mailadres</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="jan@makelaardij.nl"
+              autoComplete="email"
+              className="bg-[var(--surface-2)]"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="company">Bedrijfsnaam</Label>
+            <Input
+              id="company"
+              type="text"
+              placeholder="De Vries Makelaardij"
+              autoComplete="organization"
+              className="bg-[var(--surface-2)]"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password">Wachtwoord</Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="********"
+              autoComplete="new-password"
+              className="bg-[var(--surface-2)]"
+            />
+          </div>
+          <Button type="submit" className="w-full">
+            Account aanmaken
+          </Button>
+        </form>
+        <p
+          className="mt-6 text-center text-sm"
+          style={{ color: "var(--ink-secondary)" }}
+        >
+          Al een account?{" "}
+          <Link
+            href="/login"
+            className="font-medium"
+            style={{ color: "var(--brand)" }}
+          >
+            Inloggen
+          </Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

- Add auth layout with centered card design and BrokerApp branding
- Add login page (`/login`) with email/password form, Google OAuth button, and "forgot password" link
- Add registration page (`/registreren`) with name, email, company, and password fields

All pages use the project design system tokens and shadcn/ui components. Dutch language copy throughout.

## Linked Issue

Closes SER-142

## Test Plan

- [ ] Verify `npm run build` passes without errors
- [ ] Navigate to `/login` and confirm form renders correctly
- [ ] Navigate to `/registreren` and confirm form renders correctly
- [ ] Confirm login form submits and redirects to `/dashboard`
- [ ] Confirm registration form submits and redirects to `/dashboard`
- [ ] Verify "Registreren" link on login page navigates to `/registreren`
- [ ] Verify "Inloggen" link on registration page navigates to `/login`
- [ ] Confirm responsive layout on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)