### PR TITLE
feat(BRO-1): Create database schema, RLS policies, and seed data

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,2 @@
+[project]
+id = "sxifsobstprwrsvgjndv"

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,0 +1,280 @@
+-- ============================================================================
+-- 001_initial_schema.sql
+-- BrokerApp database schema: tables, indexes, RLS policies, triggers, storage
+-- ============================================================================
+
+-- =========================
+-- 1. TABLES
+-- =========================
+
+-- 1a. organizations
+CREATE TABLE IF NOT EXISTS organizations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  slug text UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 1b. profiles (references auth.users and organizations)
+CREATE TABLE IF NOT EXISTS profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  full_name text NOT NULL,
+  email text NOT NULL,
+  avatar_url text,
+  organization_id uuid REFERENCES organizations(id) ON DELETE SET NULL,
+  role text NOT NULL DEFAULT 'member' CHECK (role IN ('owner', 'admin', 'member')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 1c. properties (references profiles and organizations)
+CREATE TABLE IF NOT EXISTS properties (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  organization_id uuid REFERENCES organizations(id) ON DELETE SET NULL,
+  address text NOT NULL,
+  postal_code text NOT NULL,
+  city text NOT NULL,
+  price integer NOT NULL,
+  square_meters integer NOT NULL,
+  rooms smallint NOT NULL,
+  bedrooms smallint NOT NULL,
+  bathrooms smallint NOT NULL,
+  build_year smallint NOT NULL,
+  energy_label text NOT NULL,
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'generated', 'published')),
+  images text[] NOT NULL DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 1d. adverts (references properties)
+CREATE TABLE IF NOT EXISTS adverts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  property_id uuid NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text NOT NULL,
+  features text[] NOT NULL DEFAULT '{}',
+  platform text NOT NULL DEFAULT 'funda' CHECK (platform IN ('funda', 'pararius', 'jaap')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 1e. activity_log (references profiles and properties)
+CREATE TABLE IF NOT EXISTS activity_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  type text NOT NULL CHECK (type IN ('generated', 'edited', 'published')),
+  property_id uuid NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  property_address text NOT NULL,
+  platform text CHECK (platform IN ('funda', 'pararius', 'jaap')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- =========================
+-- 2. INDEXES
+-- =========================
+
+CREATE INDEX IF NOT EXISTS idx_properties_user_id ON properties(user_id);
+CREATE INDEX IF NOT EXISTS idx_properties_organization_id ON properties(organization_id);
+CREATE INDEX IF NOT EXISTS idx_properties_status ON properties(status);
+CREATE INDEX IF NOT EXISTS idx_adverts_property_id ON adverts(property_id);
+CREATE INDEX IF NOT EXISTS idx_activity_log_user_id_created_at ON activity_log(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_log_property_id ON activity_log(property_id);
+
+-- =========================
+-- 3. TRIGGER FUNCTIONS
+-- =========================
+
+-- 3a. Generic updated_at trigger function
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply updated_at trigger to tables that have updated_at
+DROP TRIGGER IF EXISTS trg_organizations_updated_at ON organizations;
+CREATE TRIGGER trg_organizations_updated_at
+  BEFORE UPDATE ON organizations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_profiles_updated_at ON profiles;
+CREATE TRIGGER trg_profiles_updated_at
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_properties_updated_at ON properties;
+CREATE TRIGGER trg_properties_updated_at
+  BEFORE UPDATE ON properties
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- 3b. Auto-create profile on auth.users signup
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (id, full_name, email, avatar_url)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', ''),
+    NEW.email,
+    NEW.raw_user_meta_data->>'avatar_url'
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION handle_new_user();
+
+-- =========================
+-- 4. ROW LEVEL SECURITY
+-- =========================
+
+-- Enable RLS on all tables
+ALTER TABLE organizations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE properties ENABLE ROW LEVEL SECURITY;
+ALTER TABLE adverts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE activity_log ENABLE ROW LEVEL SECURITY;
+
+-- 4a. organizations policies
+DROP POLICY IF EXISTS "Members can read their own organization" ON organizations;
+CREATE POLICY "Members can read their own organization"
+  ON organizations FOR SELECT
+  USING (id IN (SELECT organization_id FROM profiles WHERE profiles.id = auth.uid()));
+
+DROP POLICY IF EXISTS "Owners can update their organization" ON organizations;
+CREATE POLICY "Owners can update their organization"
+  ON organizations FOR UPDATE
+  USING (id IN (SELECT organization_id FROM profiles WHERE profiles.id = auth.uid() AND profiles.role = 'owner'));
+
+-- 4b. profiles policies
+DROP POLICY IF EXISTS "Users can read their own profile" ON profiles;
+CREATE POLICY "Users can read their own profile"
+  ON profiles FOR SELECT
+  USING (id = auth.uid());
+
+DROP POLICY IF EXISTS "Org members can read each other" ON profiles;
+CREATE POLICY "Org members can read each other"
+  ON profiles FOR SELECT
+  USING (organization_id IN (SELECT organization_id FROM profiles WHERE profiles.id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can update their own profile" ON profiles;
+CREATE POLICY "Users can update their own profile"
+  ON profiles FOR UPDATE
+  USING (id = auth.uid());
+
+-- 4c. properties policies
+DROP POLICY IF EXISTS "Users can read their own properties" ON properties;
+CREATE POLICY "Users can read their own properties"
+  ON properties FOR SELECT
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Org members can read org properties" ON properties;
+CREATE POLICY "Org members can read org properties"
+  ON properties FOR SELECT
+  USING (organization_id IN (SELECT organization_id FROM profiles WHERE profiles.id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can create their own properties" ON properties;
+CREATE POLICY "Users can create their own properties"
+  ON properties FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can update their own properties" ON properties;
+CREATE POLICY "Users can update their own properties"
+  ON properties FOR UPDATE
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can delete their own properties" ON properties;
+CREATE POLICY "Users can delete their own properties"
+  ON properties FOR DELETE
+  USING (user_id = auth.uid());
+
+-- 4d. adverts policies
+DROP POLICY IF EXISTS "Users can read their own adverts" ON adverts;
+CREATE POLICY "Users can read their own adverts"
+  ON adverts FOR SELECT
+  USING (property_id IN (SELECT id FROM properties WHERE user_id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can create adverts for their properties" ON adverts;
+CREATE POLICY "Users can create adverts for their properties"
+  ON adverts FOR INSERT
+  WITH CHECK (property_id IN (SELECT id FROM properties WHERE user_id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can update their own adverts" ON adverts;
+CREATE POLICY "Users can update their own adverts"
+  ON adverts FOR UPDATE
+  USING (property_id IN (SELECT id FROM properties WHERE user_id = auth.uid()));
+
+DROP POLICY IF EXISTS "Users can delete their own adverts" ON adverts;
+CREATE POLICY "Users can delete their own adverts"
+  ON adverts FOR DELETE
+  USING (property_id IN (SELECT id FROM properties WHERE user_id = auth.uid()));
+
+-- 4e. activity_log policies
+DROP POLICY IF EXISTS "Users can read their own activity" ON activity_log;
+CREATE POLICY "Users can read their own activity"
+  ON activity_log FOR SELECT
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can insert their own activity" ON activity_log;
+CREATE POLICY "Users can insert their own activity"
+  ON activity_log FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+-- =========================
+-- 5. STORAGE BUCKETS
+-- =========================
+
+-- 5a. Create buckets (idempotent via ON CONFLICT)
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES
+  ('property-images', 'property-images', true, 10485760, ARRAY['image/jpeg', 'image/png', 'image/webp']),
+  ('avatars', 'avatars', true, 2097152, ARRAY['image/jpeg', 'image/png', 'image/webp'])
+ON CONFLICT (id) DO NOTHING;
+
+-- 5b. Storage policies
+
+-- Public read for property-images
+DROP POLICY IF EXISTS "Public read for property images" ON storage.objects;
+CREATE POLICY "Public read for property images"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'property-images');
+
+-- Public read for avatars
+DROP POLICY IF EXISTS "Public read for avatars" ON storage.objects;
+CREATE POLICY "Public read for avatars"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'avatars');
+
+-- Authenticated users can upload to their own folder
+DROP POLICY IF EXISTS "Authenticated users can upload own files" ON storage.objects;
+CREATE POLICY "Authenticated users can upload own files"
+  ON storage.objects FOR INSERT
+  WITH CHECK (
+    (bucket_id = 'property-images' OR bucket_id = 'avatars')
+    AND auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+-- Authenticated users can update their own files
+DROP POLICY IF EXISTS "Authenticated users can update own files" ON storage.objects;
+CREATE POLICY "Authenticated users can update own files"
+  ON storage.objects FOR UPDATE
+  USING (
+    (bucket_id = 'property-images' OR bucket_id = 'avatars')
+    AND auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+-- Authenticated users can delete their own files
+DROP POLICY IF EXISTS "Authenticated users can delete own files" ON storage.objects;
+CREATE POLICY "Authenticated users can delete own files"
+  ON storage.objects FOR DELETE
+  USING (
+    (bucket_id = 'property-images' OR bucket_id = 'avatars')
+    AND auth.uid()::text = (storage.foldername(name))[1]
+  );

--- a/supabase/migrations/002_seed_data.sql
+++ b/supabase/migrations/002_seed_data.sql
@@ -1,0 +1,280 @@
+-- ============================================================================
+-- 002_seed_data.sql
+-- Seed data for BrokerApp — mirrors src/lib/mock-data.ts
+-- ============================================================================
+--
+-- FK DEPENDENCY: DEMO USER_ID
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- This seed data requires a user in auth.users to satisfy the profiles FK.
+-- The approach: we use a well-known fixed UUID as the demo user_id.
+-- A DO block first checks if this user exists in auth.users.
+-- If NOT, the seed inserts a placeholder into auth.users (only works in
+-- local/dev environments where the auth schema is writable).
+-- In production, create a real user first, then update DEMO_USER_ID below.
+--
+-- To use with a different user, change the UUID on the next line:
+-- ============================================================================
+
+DO $$
+DECLARE
+  DEMO_USER_ID  uuid := '00000000-0000-0000-0000-000000000099';
+  DEMO_ORG_ID   uuid := '00000000-0000-0000-0000-000000000001';
+  user_exists   boolean;
+  seed_exists   boolean;
+BEGIN
+  -- Guard: skip if seed data already exists
+  SELECT EXISTS(SELECT 1 FROM organizations WHERE id = DEMO_ORG_ID) INTO seed_exists;
+  IF seed_exists THEN
+    RAISE NOTICE 'Seed data already exists, skipping.';
+    RETURN;
+  END IF;
+
+  -- Check if the demo user exists in auth.users
+  SELECT EXISTS(SELECT 1 FROM auth.users WHERE id = DEMO_USER_ID) INTO user_exists;
+
+  IF NOT user_exists THEN
+    -- Insert a minimal auth.users entry for the demo user.
+    -- This works in migration context (superuser). In production,
+    -- create the user via Supabase Auth instead.
+    INSERT INTO auth.users (
+      id,
+      instance_id,
+      aud,
+      role,
+      email,
+      encrypted_password,
+      email_confirmed_at,
+      raw_app_meta_data,
+      raw_user_meta_data,
+      created_at,
+      updated_at,
+      confirmation_token,
+      email_change,
+      email_change_token_new,
+      recovery_token
+    ) VALUES (
+      DEMO_USER_ID,
+      '00000000-0000-0000-0000-000000000000',
+      'authenticated',
+      'authenticated',
+      'demo@brokerapp.nl',
+      crypt('demo-password-123', gen_salt('bf')),
+      now(),
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      '{"full_name":"Demo Makelaar"}'::jsonb,
+      now(),
+      now(),
+      '',
+      '',
+      '',
+      ''
+    );
+  END IF;
+
+  -- Ensure profile exists (handle_new_user trigger may have created it,
+  -- but insert with ON CONFLICT to be safe)
+  INSERT INTO profiles (id, full_name, email, organization_id, role)
+  VALUES (DEMO_USER_ID, 'Demo Makelaar', 'demo@brokerapp.nl', NULL, 'owner')
+  ON CONFLICT (id) DO NOTHING;
+
+  -- =========================
+  -- Organization
+  -- =========================
+  INSERT INTO organizations (id, name, slug)
+  VALUES (DEMO_ORG_ID, 'Demo Makelaardij', 'demo-makelaardij');
+
+  -- Link demo user to the organization
+  UPDATE profiles SET organization_id = DEMO_ORG_ID WHERE id = DEMO_USER_ID;
+
+  -- =========================
+  -- Properties (8 properties matching mock-data.ts)
+  -- =========================
+  INSERT INTO properties (id, user_id, organization_id, address, postal_code, city, price, square_meters, rooms, bedrooms, bathrooms, build_year, energy_label, status, images, created_at, updated_at) VALUES
+  (
+    '10000000-0000-0000-0000-000000000001', DEMO_USER_ID, DEMO_ORG_ID,
+    'Keizersgracht 482', '1017 EG', 'Amsterdam',
+    845000, 142, 5, 3, 2, 1890, 'A', 'published',
+    ARRAY['/images/property-1a.jpg', '/images/property-1b.jpg'],
+    now() - interval '14 days', now() - interval '2 days'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000002', DEMO_USER_ID, DEMO_ORG_ID,
+    'Oudegracht 156', '3511 AZ', 'Utrecht',
+    525000, 98, 4, 2, 1, 1920, 'B', 'generated',
+    ARRAY['/images/property-2a.jpg'],
+    now() - interval '7 days', now() - interval '1 day'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000003', DEMO_USER_ID, DEMO_ORG_ID,
+    'Witte de Withstraat 38', '3012 BR', 'Rotterdam',
+    375000, 85, 3, 2, 1, 2005, 'A+', 'published',
+    ARRAY['/images/property-3a.jpg', '/images/property-3b.jpg'],
+    now() - interval '21 days', now() - interval '5 days'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000004', DEMO_USER_ID, DEMO_ORG_ID,
+    'Lange Voorhout 74', '2514 EH', 'Den Haag',
+    695000, 120, 4, 3, 2, 1875, 'C', 'draft',
+    ARRAY['/images/property-4a.jpg'],
+    now() - interval '3 days', now() - interval '3 days'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000005', DEMO_USER_ID, DEMO_ORG_ID,
+    'Herengracht 320', '1016 CE', 'Amsterdam',
+    725000, 115, 4, 2, 2, 1910, 'B', 'generated',
+    ARRAY['/images/property-5a.jpg', '/images/property-5b.jpg'],
+    now() - interval '10 days', now() - interval '8 hours'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000006', DEMO_USER_ID, DEMO_ORG_ID,
+    'Mariaplaats 12', '3511 LH', 'Utrecht',
+    450000, 78, 3, 1, 1, 1955, 'D', 'draft',
+    ARRAY[]::text[],
+    now() - interval '1 day', now() - interval '1 day'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000007', DEMO_USER_ID, DEMO_ORG_ID,
+    'Noordeinde 58', '2514 GL', 'Den Haag',
+    550000, 95, 4, 2, 1, 1935, 'A++', 'published',
+    ARRAY['/images/property-7a.jpg', '/images/property-7b.jpg'],
+    now() - interval '30 days', now() - interval '10 days'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000008', DEMO_USER_ID, DEMO_ORG_ID,
+    'Coolsingel 42', '3011 AD', 'Rotterdam',
+    299000, 65, 3, 1, 1, 2018, 'A+++', 'generated',
+    ARRAY['/images/property-8a.jpg'],
+    now() - interval '5 days', now() - interval '3 hours'
+  );
+
+  -- =========================
+  -- Adverts (6 adverts matching mockAdverts)
+  -- =========================
+  INSERT INTO adverts (id, property_id, title, description, features, platform, created_at) VALUES
+  (
+    '20000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000001',
+    'Stijlvol grachtenpand aan de Keizersgracht',
+    'Dit prachtige grachtenpand uit 1890 combineert authentieke details met modern comfort. De woning beschikt over originele ornamenten, hoge plafonds en grote ramen die zorgen voor een overvloed aan natuurlijk licht. De volledig gerenoveerde keuken en badkamers bieden alle hedendaagse gemakken. Gelegen aan een van de mooiste grachten van Amsterdam, met winkels, restaurants en het Rijksmuseum op loopafstand.',
+    ARRAY['Originele ornamenten en schouwen', 'Volledig gerenoveerde keuken met inbouwapparatuur', 'Twee luxe badkamers met vloerverwarming', 'Uitzicht over de Keizersgracht', 'Energielabel A — uitstekend geïsoleerd'],
+    'funda',
+    now() - interval '5 days'
+  ),
+  (
+    '20000000-0000-0000-0000-000000000002',
+    '10000000-0000-0000-0000-000000000002',
+    'Karakteristiek werfkelderwoningen aan de Oudegracht',
+    'Unieke woning aan de beroemde Oudegracht in het hart van Utrecht. Deze charmante woning uit 1920 biedt een bijzondere woervaring met directe toegang tot de werf. De lichte woonkamer met originele balkenplafonds en de moderne open keuken maken dit tot een droomwoning voor liefhebbers van stadswonen met karakter.',
+    ARRAY['Directe toegang tot de Oudegracht-werf', 'Originele balkenplafonds', 'Moderne open keuken', 'Midden in het centrum van Utrecht'],
+    'pararius',
+    now() - interval '3 days'
+  ),
+  (
+    '20000000-0000-0000-0000-000000000003',
+    '10000000-0000-0000-0000-000000000003',
+    'Modern appartement in het bruisende Rotterdam',
+    'Licht en ruim appartement in het populaire Witte de Withkwartier. Dit moderne appartement uit 2005 is perfect voor wie wil genieten van het stadsleven. De open woonkeuken, het ruime balkon en de nabijheid van culturele hotspots zoals het Museumpark maken deze woning ideaal voor jong professionals en stellen.',
+    ARRAY['Ruim balkon op het zuiden', 'Open woonkeuken met kookeiland', 'Energielabel A+ — zeer energiezuinig', 'Op loopafstand van Museumpark en Erasmusbrug', 'Eigen parkeerplaats in de garage'],
+    'funda',
+    now() - interval '8 days'
+  ),
+  (
+    '20000000-0000-0000-0000-000000000004',
+    '10000000-0000-0000-0000-000000000005',
+    'Elegant herenhuis aan de Herengracht',
+    'Sfeervol herenhuis uit 1910 aan de prestigieuze Herengracht. Deze woning straalt klasse uit met zijn hoge plafonds, sierlijke gevel en prachtige erker. De combinatie van authentieke elementen en moderne voorzieningen maakt dit een unieke kans in het hart van Amsterdam. Twee royale badkamers en een zonnige achtertuin completeren het geheel.',
+    ARRAY['Monumentale gevel met erker', 'Hoge plafonds met stucwerk', 'Twee luxe badkamers', 'Zonnige achtertuin op het westen', 'Kelder met bergruimte'],
+    'jaap',
+    now() - interval '2 days'
+  ),
+  (
+    '20000000-0000-0000-0000-000000000005',
+    '10000000-0000-0000-0000-000000000007',
+    'Gerenoveerde stadswoning nabij het Noordeinde',
+    'Prachtig gerenoveerde stadswoning uit 1935 in het gewilde Noordeinde-kwartier van Den Haag. Dankzij de recente renovatie beschikt deze woning over energielabel A++ en alle moderne gemakken, terwijl het oorspronkelijke karakter behouden is gebleven. De locatie nabij het Paleis Noordeinde, de Passage en het strand van Scheveningen maakt deze woning bijzonder aantrekkelijk.',
+    ARRAY['Energielabel A++ na volledige renovatie', 'Oorspronkelijke details behouden', 'Nabij Paleis Noordeinde en de Passage', '15 minuten fietsen naar Scheveningen'],
+    'funda',
+    now() - interval '15 days'
+  ),
+  (
+    '20000000-0000-0000-0000-000000000006',
+    '10000000-0000-0000-0000-000000000008',
+    'Nieuwbouwappartement aan de Coolsingel',
+    'Stijlvol nieuwbouwappartement uit 2018 aan de volledig vernieuwde Coolsingel. Dit compacte maar slim ingedeelde appartement biedt alles wat een moderne stadsbewoner nodig heeft. Met energielabel A+++ zijn de energiekosten minimaal. De centrale ligging bij Rotterdam Centraal en de Markthal maakt dit de perfecte stadswoning.',
+    ARRAY['Energielabel A+++ — bijna energieneutraal', 'Slimme indeling met veel bergruimte', 'Aan de vernieuwde Coolsingel', '5 minuten lopen naar Rotterdam Centraal', 'Gemeenschappelijk dakterras'],
+    'pararius',
+    now() - interval '4 hours'
+  );
+
+  -- =========================
+  -- Activity Log (11 entries matching mockActivityFeed)
+  -- =========================
+  INSERT INTO activity_log (id, user_id, type, property_id, property_address, platform, created_at) VALUES
+  (
+    '30000000-0000-0000-0000-000000000001', DEMO_USER_ID,
+    'generated', '10000000-0000-0000-0000-000000000008',
+    'Coolsingel 42, Rotterdam', NULL,
+    now() - interval '3 hours'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000002', DEMO_USER_ID,
+    'edited', '10000000-0000-0000-0000-000000000005',
+    'Herengracht 320, Amsterdam', NULL,
+    now() - interval '8 hours'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000003', DEMO_USER_ID,
+    'published', '10000000-0000-0000-0000-000000000001',
+    'Keizersgracht 482, Amsterdam', 'funda',
+    now() - interval '2 days'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000004', DEMO_USER_ID,
+    'generated', '10000000-0000-0000-0000-000000000002',
+    'Oudegracht 156, Utrecht', NULL,
+    now() - interval '1 day'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000005', DEMO_USER_ID,
+    'published', '10000000-0000-0000-0000-000000000003',
+    'Witte de Withstraat 38, Rotterdam', 'pararius',
+    now() - interval '5 days'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000006', DEMO_USER_ID,
+    'edited', '10000000-0000-0000-0000-000000000001',
+    'Keizersgracht 482, Amsterdam', NULL,
+    now() - interval '3 days'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000007', DEMO_USER_ID,
+    'generated', '10000000-0000-0000-0000-000000000005',
+    'Herengracht 320, Amsterdam', NULL,
+    now() - interval '4 days'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000008', DEMO_USER_ID,
+    'published', '10000000-0000-0000-0000-000000000007',
+    'Noordeinde 58, Den Haag', 'jaap',
+    now() - interval '10 days'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000009', DEMO_USER_ID,
+    'generated', '10000000-0000-0000-0000-000000000003',
+    'Witte de Withstraat 38, Rotterdam', NULL,
+    now() - interval '6 days'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000010', DEMO_USER_ID,
+    'edited', '10000000-0000-0000-0000-000000000007',
+    'Noordeinde 58, Den Haag', NULL,
+    now() - interval '11 days'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000011', DEMO_USER_ID,
+    'generated', '10000000-0000-0000-0000-000000000007',
+    'Noordeinde 58, Den Haag', NULL,
+    now() - interval '12 days'
+  );
+
+END $$;


### PR DESCRIPTION
## Summary

- **Database schema**: 5 tables (organizations, profiles, properties, adverts, activity_log) with proper foreign key relationships, indexes, and constraints
- **RLS policies**: Row Level Security enabled on all tables with user-scoped and organization-scoped read/write policies
- **Triggers**: Auto-updating `updated_at` timestamps and auto-creating profiles on auth.users signup
- **Storage buckets**: `property-images` and `avatars` with public read access and user-scoped upload/update/delete policies
- **Seed data**: 8 properties, 6 adverts, and 11 activity log entries mirroring `src/lib/mock-data.ts` with idempotent insertion

## Files Changed

| File | Description |
|------|-------------|
| `supabase/config.toml` | Supabase project configuration with project ID |
| `supabase/migrations/001_initial_schema.sql` | Tables, indexes, triggers, RLS policies, storage buckets |
| `supabase/migrations/002_seed_data.sql` | Demo user, organization, properties, adverts, activity log |

## Test Plan

- [ ] Apply migration 001 against a fresh Supabase instance — all tables, indexes, triggers, and policies created without errors
- [ ] Apply migration 002 — seed data inserted correctly with demo user
- [ ] Run migration 002 a second time — idempotent guard skips re-insertion
- [ ] Verify RLS: authenticated user can only read/write their own data
- [ ] Verify storage policies: users can upload to their own folder, public read works
- [ ] Verify `handle_new_user` trigger creates profile on auth signup

Resolves BRO-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)