### PR TITLE
feat(BRO-4): Add auth middleware and route protection

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,10 +1,21 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
 import { Sidebar } from "@/components/layout/sidebar";
 
-export default function AppLayout({
+export default async function AppLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
   return (
     <div className="flex min-h-screen bg-[var(--canvas)]">
       <Sidebar />

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,53 @@
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+const protectedPaths = ["/dashboard", "/nieuw", "/advertentie"];
+const authPaths = ["/login", "/registreren"];
+
+export async function middleware(request: NextRequest) {
+  // Refresh session tokens via the existing helper
+  const supabaseResponse = await updateSession(request);
+
+  // Create a client from the updated request to check user
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll() {},
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { pathname } = request.nextUrl;
+
+  // Unauthenticated user on protected route -> redirect to /login
+  if (!user && protectedPaths.some((p) => pathname.startsWith(p))) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    return NextResponse.redirect(url);
+  }
+
+  // Authenticated user on auth route -> redirect to /dashboard
+  if (user && authPaths.some((p) => pathname.startsWith(p))) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/dashboard";
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

- Adds Next.js middleware that refreshes Supabase session tokens and enforces route protection: unauthenticated users on protected routes are redirected to /login; authenticated users on auth routes are redirected to /dashboard
- Converts the (app) layout to an async server component with a secondary server-side auth guard
- Uses the updateSession helper for cookie-based session refresh

## Test plan

- [ ] Verify unauthenticated users are redirected from protected routes to /login
- [ ] Verify authenticated users are redirected from auth routes to /dashboard
- [ ] Verify session tokens are refreshed on each request

Resolves BRO-4