### PR TITLE
feat(BRO-3): Wire login and registration pages to Supabase Auth

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -12,13 +13,69 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { createClient } from "@/lib/supabase/client";
 
 export default function LoginPage() {
   const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    router.push("/dashboard");
+    setError("");
+
+    if (!email.trim()) {
+      setError("E-mailadres is verplicht");
+      return;
+    }
+    if (!password) {
+      setError("Wachtwoord is verplicht");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const supabase = createClient();
+      const { error: authError } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (authError) {
+        setError("Ongeldige inloggegevens");
+        return;
+      }
+
+      router.push("/dashboard");
+    } catch {
+      setError("Er ging iets mis. Probeer het opnieuw.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function handleGoogleLogin() {
+    setError("");
+    setIsLoading(true);
+    try {
+      const supabase = createClient();
+      const { error: authError } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: `${window.location.origin}/dashboard`,
+        },
+      });
+
+      if (authError) {
+        setError("Er ging iets mis. Probeer het opnieuw.");
+        setIsLoading(false);
+      }
+    } catch {
+      setError("Er ging iets mis. Probeer het opnieuw.");
+      setIsLoading(false);
+    }
   }
 
   return (
@@ -47,6 +104,8 @@ export default function LoginPage() {
               placeholder="jan@makelaardij.nl"
               autoComplete="email"
               className="bg-[var(--surface-2)]"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
             />
           </div>
           <div className="flex flex-col gap-2">
@@ -66,10 +125,17 @@ export default function LoginPage() {
               placeholder="********"
               autoComplete="current-password"
               className="bg-[var(--surface-2)]"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
             />
           </div>
-          <Button type="submit" className="w-full">
-            Inloggen
+          {error && (
+            <p className="text-sm" style={{ color: "var(--destructive)" }}>
+              {error}
+            </p>
+          )}
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? "Bezig met inloggen..." : "Inloggen"}
           </Button>
           <div className="relative flex items-center gap-4">
             <div
@@ -87,7 +153,13 @@ export default function LoginPage() {
               style={{ backgroundColor: "var(--border-emphasis)" }}
             />
           </div>
-          <Button type="button" variant="outline" className="w-full">
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            disabled={isLoading}
+            onClick={handleGoogleLogin}
+          >
             <svg
               className="mr-2 h-4 w-4"
               viewBox="0 0 24 24"

--- a/src/app/(auth)/registreren/page.tsx
+++ b/src/app/(auth)/registreren/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -12,13 +13,111 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { createClient } from "@/lib/supabase/client";
 
 export default function RegistrerenPage() {
   const router = useRouter();
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [companyName, setCompanyName] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    router.push("/dashboard");
+    setError("");
+
+    if (!fullName.trim()) {
+      setError("Naam is verplicht");
+      return;
+    }
+    if (!email.trim()) {
+      setError("E-mailadres is verplicht");
+      return;
+    }
+    if (!companyName.trim()) {
+      setError("Bedrijfsnaam is verplicht");
+      return;
+    }
+    if (!password) {
+      setError("Wachtwoord is verplicht");
+      return;
+    }
+    if (password.length < 6) {
+      setError("Wachtwoord moet minimaal 6 tekens bevatten");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const supabase = createClient();
+      const { data: signUpData, error: signUpError } =
+        await supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            data: {
+              full_name: fullName,
+              company_name: companyName,
+            },
+          },
+        });
+
+      if (signUpError) {
+        if (signUpError.message.includes("already registered")) {
+          setError("Er bestaat al een account met dit e-mailadres");
+        } else {
+          setError("Er ging iets mis. Probeer het opnieuw.");
+        }
+        return;
+      }
+
+      // If email confirmation is required, session will be null
+      if (!signUpData.session) {
+        setError("Controleer je e-mail om je account te bevestigen.");
+        return;
+      }
+
+      const user = signUpData.user;
+      if (!user) {
+        setError("Er ging iets mis. Probeer het opnieuw.");
+        return;
+      }
+
+      // Create organization
+      const { data: org, error: orgError } = await supabase
+        .from("organizations")
+        .insert({ name: companyName })
+        .select()
+        .single();
+
+      if (orgError) {
+        setError("Er ging iets mis. Probeer het opnieuw.");
+        return;
+      }
+
+      // Link profile to organization (profile created by handle_new_user trigger)
+      const { error: profileError } = await supabase
+        .from("profiles")
+        .update({ organization_id: org.id })
+        .eq("id", user.id);
+
+      if (profileError) {
+        // Retry once in case the trigger hasn't fired yet
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        await supabase
+          .from("profiles")
+          .update({ organization_id: org.id })
+          .eq("id", user.id);
+      }
+
+      router.push("/dashboard");
+    } catch {
+      setError("Er ging iets mis. Probeer het opnieuw.");
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   return (
@@ -47,6 +146,8 @@ export default function RegistrerenPage() {
               placeholder="Jan de Vries"
               autoComplete="name"
               className="bg-[var(--surface-2)]"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
             />
           </div>
           <div className="flex flex-col gap-2">
@@ -57,6 +158,8 @@ export default function RegistrerenPage() {
               placeholder="jan@makelaardij.nl"
               autoComplete="email"
               className="bg-[var(--surface-2)]"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
             />
           </div>
           <div className="flex flex-col gap-2">
@@ -67,6 +170,8 @@ export default function RegistrerenPage() {
               placeholder="De Vries Makelaardij"
               autoComplete="organization"
               className="bg-[var(--surface-2)]"
+              value={companyName}
+              onChange={(e) => setCompanyName(e.target.value)}
             />
           </div>
           <div className="flex flex-col gap-2">
@@ -77,10 +182,17 @@ export default function RegistrerenPage() {
               placeholder="********"
               autoComplete="new-password"
               className="bg-[var(--surface-2)]"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
             />
           </div>
-          <Button type="submit" className="w-full">
-            Account aanmaken
+          {error && (
+            <p className="text-sm" style={{ color: "var(--destructive)" }}>
+              {error}
+            </p>
+          )}
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? "Account aanmaken..." : "Account aanmaken"}
           </Button>
         </form>
         <p

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import type { User, Session } from "@supabase/supabase-js";
+
+interface UseAuthReturn {
+  user: User | null;
+  session: Session | null;
+  isLoading: boolean;
+  signOut: () => Promise<void>;
+}
+
+export function useAuth(): UseAuthReturn {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+      setUser(session?.user ?? null);
+      setIsLoading(false);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  async function signOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/login");
+  }
+
+  return { user, session, isLoading, signOut };
+}


### PR DESCRIPTION
## Summary

- Wires the login page (`/login`) to Supabase `signInWithPassword` and adds Google OAuth login via `signInWithOAuth`
- Wires the registration page (`/registreren`) to Supabase `signUp` with full_name/company_name metadata, plus automatic organization creation and profile linking
- Adds a `useAuth` hook (`src/hooks/use-auth.ts`) that manages session state, listens to auth state changes, and provides a `signOut` helper
- Includes client-side validation with Dutch error messages and loading states on both forms

## Changed Files

- `src/app/(auth)/login/page.tsx` — Replaced stub handler with Supabase email/password + Google OAuth
- `src/app/(auth)/registreren/page.tsx` — Replaced stub handler with Supabase signUp, org creation, and profile update
- `src/hooks/use-auth.ts` — New hook for auth session management

## Test Plan

- [ ] Verify login with valid Supabase credentials redirects to `/dashboard`
- [ ] Verify login with invalid credentials shows Dutch error message
- [ ] Verify Google OAuth button initiates OAuth flow
- [ ] Verify registration creates user, organization, and links profile
- [ ] Verify form validation shows appropriate Dutch error messages
- [ ] Verify loading states disable buttons during submission
- [ ] Verify `useAuth` hook tracks session changes and provides `signOut`

Resolves BRO-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)