### PR TITLE
feat(BRO-6): Build properties data layer with React Query hooks

### DIFF
--- a/src/app/(app)/nieuw/page.tsx
+++ b/src/app/(app)/nieuw/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { Header } from "@/components/layout/header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ImageGallery, type ImageFile } from "@/components/upload/image-gallery";
@@ -11,8 +12,9 @@ import {
 } from "@/components/upload/property-form";
 import { GenerateButton } from "@/components/upload/generate-button";
 import { useGenerate } from "@/hooks/use-generate";
+import { useAuth } from "@/hooks/use-auth";
+import { useCreateProperty } from "@/hooks/use-properties";
 import { PropertyStatus } from "@/lib/types";
-import type { Property } from "@/lib/types";
 
 function isFormComplete(data: PropertyFormData, images: ImageFile[]): boolean {
   return (
@@ -30,38 +32,53 @@ function isFormComplete(data: PropertyFormData, images: ImageFile[]): boolean {
   );
 }
 
-function formToProperty(data: PropertyFormData, images: ImageFile[]): Property {
-  return {
-    id: `prop-${Date.now()}`,
-    address: data.address,
-    postalCode: data.postalCode,
-    city: data.city,
-    price: Number(data.price),
-    squareMeters: Number(data.squareMeters),
-    rooms: Number(data.rooms),
-    bedrooms: Number(data.bedrooms),
-    bathrooms: Number(data.bathrooms),
-    buildYear: Number(data.buildYear),
-    energyLabel: data.energyLabel,
-    status: PropertyStatus.Draft,
-    images: images.map((img) => img.previewUrl),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
-}
-
 export default function NieuwPage() {
+  const router = useRouter();
+  const { user } = useAuth();
   const [formData, setFormData] = useState<PropertyFormData>(emptyFormData);
   const [images, setImages] = useState<ImageFile[]>([]);
-  const { advert, isLoading, error, generate } = useGenerate();
+  const { advert, isLoading: isGenerating, error: generateError, generate } = useGenerate();
+  const { createProperty, isCreating, error: createError } = useCreateProperty();
+
+  const propertyId = useMemo(() => crypto.randomUUID(), []);
 
   const isReady = isFormComplete(formData, images);
+  const isLoading = isGenerating || isCreating;
+  const error = createError
+    ? createError instanceof Error
+      ? createError.message
+      : "Er ging iets mis bij het opslaan"
+    : generateError;
 
-  const handleGenerate = useCallback(() => {
-    if (!isReady) return;
-    const property = formToProperty(formData, images);
-    generate(property);
-  }, [isReady, formData, images, generate]);
+  const handleGenerate = useCallback(async () => {
+    if (!isReady || !user) return;
+
+    try {
+      const imageUrls = images.map((img) => img.storagePath ?? img.previewUrl);
+
+      const property = await createProperty({
+        id: propertyId,
+        userId: user.id,
+        address: formData.address,
+        postalCode: formData.postalCode,
+        city: formData.city,
+        price: Number(formData.price),
+        squareMeters: Number(formData.squareMeters),
+        rooms: Number(formData.rooms),
+        bedrooms: Number(formData.bedrooms),
+        bathrooms: Number(formData.bathrooms),
+        buildYear: Number(formData.buildYear),
+        energyLabel: formData.energyLabel,
+        status: PropertyStatus.Draft,
+        images: imageUrls,
+      });
+
+      generate(property);
+      router.push(`/advertentie/${property.id}`);
+    } catch {
+      // Error is handled via the createError state from the mutation
+    }
+  }, [isReady, user, images, createProperty, propertyId, formData, generate, router]);
 
   return (
     <div>
@@ -77,7 +94,12 @@ export default function NieuwPage() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <ImageGallery images={images} onImagesChange={setImages} />
+              <ImageGallery
+                images={images}
+                onImagesChange={setImages}
+                userId={user?.id}
+                propertyId={propertyId}
+              />
             </CardContent>
           </Card>
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LayoutDashboard, Plus, Menu, X, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { mockProperties } from "@/lib/mock-data";
+import { useAuth } from "@/hooks/use-auth";
+import { useRecentProperties } from "@/hooks/use-properties";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -15,11 +16,24 @@ const navLinks = [
   { href: "/nieuw", label: "Nieuwe advertentie", icon: Plus },
 ];
 
-const recentProperties = mockProperties.slice(0, 3);
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
 
 export function Sidebar() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { user } = useAuth();
+  const { properties: recentProperties, isLoading } = useRecentProperties(3);
+
+  const displayName = user?.user_metadata?.full_name ?? "Gebruiker";
+  const initials = getInitials(displayName);
 
   return (
     <>
@@ -102,23 +116,50 @@ export function Sidebar() {
             Recente woningen
           </p>
           <div className="mt-[var(--space-2)] flex flex-col gap-[var(--space-1)]">
-            {recentProperties.map((property) => (
-              <Link
-                key={property.id}
-                href={
-                  property.status === "draft"
-                    ? "/nieuw"
-                    : `/advertentie/${property.id}`
-                }
-                onClick={() => setMobileOpen(false)}
-                className="flex items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] px-[var(--space-3)] py-[var(--space-2)] text-[13px] text-[var(--ink-secondary)] transition-colors duration-150 hover:bg-[var(--surface-2)]"
-              >
-                <Home className="size-3.5 shrink-0 text-[var(--ink-tertiary)]" />
-                <span className="truncate">
-                  {property.address}, {property.city}
-                </span>
-              </Link>
-            ))}
+            {isLoading ? (
+              <>
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] px-[var(--space-3)] py-[var(--space-2)]"
+                  >
+                    <div className="size-3.5 shrink-0 rounded-sm bg-[var(--surface-3)] animate-pulse" />
+                    <div className="h-3.5 flex-1 rounded-sm bg-[var(--surface-3)] animate-pulse" />
+                  </div>
+                ))}
+              </>
+            ) : recentProperties.length === 0 ? (
+              <div className="px-[var(--space-3)] py-[var(--space-2)]">
+                <p className="text-[13px] text-[var(--ink-tertiary)]">
+                  Nog geen woningen
+                </p>
+                <Link
+                  href="/nieuw"
+                  onClick={() => setMobileOpen(false)}
+                  className="mt-[var(--space-1)] inline-block text-[13px] font-medium text-[var(--brand)] hover:text-[var(--brand-hover)]"
+                >
+                  Eerste woning toevoegen
+                </Link>
+              </div>
+            ) : (
+              recentProperties.map((property) => (
+                <Link
+                  key={property.id}
+                  href={
+                    property.status === "draft"
+                      ? "/nieuw"
+                      : `/advertentie/${property.id}`
+                  }
+                  onClick={() => setMobileOpen(false)}
+                  className="flex items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] px-[var(--space-3)] py-[var(--space-2)] text-[13px] text-[var(--ink-secondary)] transition-colors duration-150 hover:bg-[var(--surface-2)]"
+                >
+                  <Home className="size-3.5 shrink-0 text-[var(--ink-tertiary)]" />
+                  <span className="truncate">
+                    {property.address}, {property.city}
+                  </span>
+                </Link>
+              ))
+            )}
           </div>
         </div>
 
@@ -131,11 +172,11 @@ export function Sidebar() {
           <div className="flex items-center gap-[var(--space-3)] rounded-[var(--radius-sm)] px-[var(--space-3)] py-[var(--space-2)]">
             <Avatar>
               <AvatarFallback className="bg-[var(--brand-subtle)] text-[var(--brand)] text-[13px] font-medium">
-                JV
+                {initials}
               </AvatarFallback>
             </Avatar>
             <span className="text-[14px] font-medium text-[var(--ink)]">
-              Jan de Vries
+              {displayName}
             </span>
           </div>
         </div>

--- a/src/hooks/use-properties.ts
+++ b/src/hooks/use-properties.ts
@@ -1,16 +1,114 @@
 "use client";
 
-import { mockProperties } from "@/lib/mock-data";
-import { Property, PropertyStatus } from "@/lib/types";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import {
+  queryKeys,
+  getProperties,
+  getPropertyById,
+  getRecentProperties,
+} from "@/lib/supabase/queries";
+import {
+  createProperty,
+  updateProperty,
+  deleteProperty,
+} from "@/lib/supabase/mutations";
+import type { CreatePropertyInput } from "@/lib/supabase/mutations";
+import type { Property, PropertyStatus } from "@/lib/types";
 
 export function useProperties(status?: PropertyStatus) {
-  const properties = status
-    ? mockProperties.filter((p) => p.status === status)
-    : mockProperties;
+  const supabase = createClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: status
+      ? [...queryKeys.properties.all, status]
+      : queryKeys.properties.all,
+    queryFn: () => getProperties(supabase, status),
+  });
+
+  const properties = data ?? [];
 
   function getById(id: string): Property | undefined {
-    return mockProperties.find((p) => p.id === id);
+    return properties.find((p) => p.id === id);
   }
 
-  return { properties, getById };
+  return { properties, getById, isLoading, error };
+}
+
+export function useProperty(id: string | undefined) {
+  const supabase = createClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.properties.detail(id ?? ""),
+    queryFn: () => getPropertyById(supabase, id!),
+    enabled: !!id,
+  });
+
+  return { property: data ?? null, isLoading, error };
+}
+
+export function useRecentProperties(limit = 3) {
+  const supabase = createClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.properties.recent(limit),
+    queryFn: () => getRecentProperties(supabase, limit),
+  });
+
+  return { properties: data ?? [], isLoading };
+}
+
+export function useCreateProperty() {
+  const supabase = createClient();
+  const queryClient = useQueryClient();
+
+  const { mutateAsync, isPending, error } = useMutation({
+    mutationFn: (data: CreatePropertyInput) => createProperty(supabase, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
+      queryClient.invalidateQueries({
+        queryKey: ["properties", "recent"],
+      });
+    },
+  });
+
+  return { createProperty: mutateAsync, isCreating: isPending, error };
+}
+
+export function useUpdateProperty() {
+  const supabase = createClient();
+  const queryClient = useQueryClient();
+
+  const { mutateAsync, isPending, error } = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Partial<CreatePropertyInput> }) =>
+      updateProperty(supabase, id, data),
+    onSuccess: (_result, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
+      queryClient.invalidateQueries({
+        queryKey: ["properties", "recent"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.properties.detail(variables.id),
+      });
+    },
+  });
+
+  return { updateProperty: mutateAsync, isUpdating: isPending, error };
+}
+
+export function useDeleteProperty() {
+  const supabase = createClient();
+  const queryClient = useQueryClient();
+
+  const { mutateAsync, isPending, error } = useMutation({
+    mutationFn: (id: string) => deleteProperty(supabase, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
+      queryClient.invalidateQueries({
+        queryKey: ["properties", "recent"],
+      });
+    },
+  });
+
+  return { deleteProperty: mutateAsync, isDeleting: isPending, error };
 }

--- a/src/lib/supabase/mutations.ts
+++ b/src/lib/supabase/mutations.ts
@@ -1,0 +1,98 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Property } from "@/lib/types";
+import type { PropertyStatus } from "@/lib/types";
+import { mapRowToProperty } from "@/lib/supabase/queries";
+import type { PropertyRow } from "@/lib/supabase/queries";
+
+export interface CreatePropertyInput {
+  id?: string;
+  userId: string;
+  organizationId?: string | null;
+  address: string;
+  postalCode: string;
+  city: string;
+  price: number;
+  squareMeters: number;
+  rooms: number;
+  bedrooms: number;
+  bathrooms: number;
+  buildYear: number;
+  energyLabel: string;
+  status?: PropertyStatus;
+  images?: string[];
+}
+
+function mapInputToRow(
+  input: CreatePropertyInput | Partial<CreatePropertyInput>
+): Record<string, unknown> {
+  const row: Record<string, unknown> = {};
+
+  if (input.id !== undefined) row.id = input.id;
+  if ("userId" in input) row.user_id = input.userId;
+  if ("organizationId" in input) row.organization_id = input.organizationId;
+  if ("address" in input) row.address = input.address;
+  if ("postalCode" in input) row.postal_code = input.postalCode;
+  if ("city" in input) row.city = input.city;
+  if ("price" in input) row.price = input.price;
+  if ("squareMeters" in input) row.square_meters = input.squareMeters;
+  if ("rooms" in input) row.rooms = input.rooms;
+  if ("bedrooms" in input) row.bedrooms = input.bedrooms;
+  if ("bathrooms" in input) row.bathrooms = input.bathrooms;
+  if ("buildYear" in input) row.build_year = input.buildYear;
+  if ("energyLabel" in input) row.energy_label = input.energyLabel;
+  if ("status" in input) row.status = input.status;
+  if ("images" in input) row.images = input.images;
+
+  return row;
+}
+
+export async function createProperty(
+  supabase: SupabaseClient,
+  data: CreatePropertyInput
+): Promise<Property> {
+  const row = mapInputToRow(data);
+
+  const { data: inserted, error } = await supabase
+    .from("properties")
+    .insert(row)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Woning aanmaken mislukt: ${error.message}`);
+  }
+
+  return mapRowToProperty(inserted as PropertyRow);
+}
+
+export async function updateProperty(
+  supabase: SupabaseClient,
+  id: string,
+  data: Partial<CreatePropertyInput>
+): Promise<Property> {
+  const row = mapInputToRow(data);
+
+  const { data: updated, error } = await supabase
+    .from("properties")
+    .update(row)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Woning bijwerken mislukt: ${error.message}`);
+  }
+
+  return mapRowToProperty(updated as PropertyRow);
+}
+
+export async function deleteProperty(
+  supabase: SupabaseClient,
+  id: string
+): Promise<void> {
+  const { error } = await supabase.from("properties").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`Woning verwijderen mislukt: ${error.message}`);
+  }
+}

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -1,0 +1,110 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { PropertyStatus } from "@/lib/types";
+import type { Property } from "@/lib/types";
+
+export interface PropertyRow {
+  id: string;
+  user_id: string;
+  organization_id: string | null;
+  address: string;
+  postal_code: string;
+  city: string;
+  price: number;
+  square_meters: number;
+  rooms: number;
+  bedrooms: number;
+  bathrooms: number;
+  build_year: number;
+  energy_label: string;
+  status: string;
+  images: string[] | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export function mapRowToProperty(row: PropertyRow): Property {
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    organization_id: row.organization_id,
+    address: row.address,
+    postalCode: row.postal_code,
+    city: row.city,
+    price: row.price,
+    squareMeters: row.square_meters,
+    rooms: row.rooms,
+    bedrooms: row.bedrooms,
+    bathrooms: row.bathrooms,
+    buildYear: row.build_year,
+    energyLabel: row.energy_label,
+    status: row.status as PropertyStatus,
+    images: row.images ?? [],
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+export const queryKeys = {
+  properties: {
+    all: ["properties"] as const,
+    detail: (id: string) => ["properties", id] as const,
+    recent: (limit: number) => ["properties", "recent", limit] as const,
+  },
+} as const;
+
+export async function getProperties(
+  supabase: SupabaseClient,
+  status?: PropertyStatus
+): Promise<Property[]> {
+  let query = supabase
+    .from("properties")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (status) {
+    query = query.eq("status", status);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Woningen ophalen mislukt: ${error.message}`);
+  }
+
+  return (data as PropertyRow[]).map(mapRowToProperty);
+}
+
+export async function getPropertyById(
+  supabase: SupabaseClient,
+  id: string
+): Promise<Property | null> {
+  const { data, error } = await supabase
+    .from("properties")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") return null;
+    throw new Error(`Woning ophalen mislukt: ${error.message}`);
+  }
+
+  return data ? mapRowToProperty(data as PropertyRow) : null;
+}
+
+export async function getRecentProperties(
+  supabase: SupabaseClient,
+  limit = 3
+): Promise<Property[]> {
+  const { data, error } = await supabase
+    .from("properties")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Recente woningen ophalen mislukt: ${error.message}`);
+  }
+
+  return (data as PropertyRow[]).map(mapRowToProperty);
+}


### PR DESCRIPTION
## Summary

Replaces mock property data with a real Supabase data layer using React Query, establishing the core CRUD operations for property management.

- **New query layer** (`src/lib/supabase/queries.ts`): Centralized query keys, row mapper (snake_case to camelCase), and typed read functions (`getProperties`, `getPropertyById`, `getRecentProperties`)
- **New mutation layer** (`src/lib/supabase/mutations.ts`): Typed write functions (`createProperty`, `updateProperty`, `deleteProperty`) with input mapper (camelCase to snake_case)
- **Rewritten hooks** (`src/hooks/use-properties.ts`): React Query hooks with automatic cache invalidation — `useProperties`, `useProperty`, `useRecentProperties`, `useCreateProperty`, `useUpdateProperty`, `useDeleteProperty`
- **Updated sidebar**: Shows authenticated user info and real recent properties with loading skeletons and empty state CTA
- **Updated nieuw page**: Creates properties in Supabase with client-generated UUID for image association, redirects to editor on success

## Test plan

- [ ] Verify `npm run build` passes without errors
- [ ] Verify `npm run lint` passes without warnings
- [ ] Test property creation flow: navigate to `/nieuw`, fill form, confirm property is created in Supabase
- [ ] Test sidebar shows recent properties for authenticated user
- [ ] Test sidebar shows loading skeleton while fetching
- [ ] Test sidebar shows empty state with link to `/nieuw` when no properties exist
- [ ] Verify React Query cache invalidation after create/update/delete mutations

Closes BRO-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)