### PR TITLE
feat(BRO-8): Create Gemini Edge Function and wire generation hook

### DIFF
--- a/src/hooks/use-generate.ts
+++ b/src/hooks/use-generate.ts
@@ -1,8 +1,18 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { generateAdvert } from "@/lib/mock-ai";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { queryKeys } from "@/lib/supabase/queries";
 import type { Property, Advert } from "@/lib/types";
+import { Platform, PropertyStatus } from "@/lib/types";
+
+interface GenerateResponse {
+  title: string;
+  description: string;
+  features: string[];
+  platform: string;
+}
 
 interface UseGenerateReturn {
   advert: Advert | null;
@@ -12,31 +22,159 @@ interface UseGenerateReturn {
   reset: () => void;
 }
 
+function mapErrorMessage(status: number): string {
+  switch (status) {
+    case 401:
+      return "U bent niet ingelogd. Log opnieuw in.";
+    case 400:
+      return "Onvolledige woninggegevens. Controleer alle velden.";
+    default:
+      return "Generatie mislukt, probeer het opnieuw.";
+  }
+}
+
 export function useGenerate(): UseGenerateReturn {
   const [advert, setAdvert] = useState<Advert | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
-  const generate = useCallback(async (property: Property) => {
-    setIsLoading(true);
-    setError(null);
-    setAdvert(null);
+  const mutation = useMutation({
+    mutationFn: async (property: Property) => {
+      const supabase = createClient();
 
-    try {
-      const result = await generateAdvert(property);
-      setAdvert(result);
-    } catch {
-      setError("Er ging iets mis bij het genereren. Probeer het opnieuw.");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+      const { data, error: fnError } = await supabase.functions.invoke<GenerateResponse>(
+        "generate-advert",
+        {
+          body: {
+            propertyId: property.id,
+            address: property.address,
+            city: property.city,
+            price: property.price,
+            squareMeters: property.squareMeters,
+            rooms: property.rooms,
+            bedrooms: property.bedrooms,
+            bathrooms: property.bathrooms,
+            buildYear: property.buildYear,
+            energyLabel: property.energyLabel,
+            images: property.images,
+          },
+        }
+      );
+
+      if (fnError) {
+        // supabase.functions.invoke wraps non-2xx responses as FunctionsHttpError
+        const status =
+          "context" in fnError && typeof fnError.context === "object" && fnError.context !== null
+            ? (fnError.context as { status?: number }).status
+            : undefined;
+        throw new Error(mapErrorMessage(status ?? 500));
+      }
+
+      if (!data) {
+        throw new Error("Generatie mislukt, probeer het opnieuw.");
+      }
+
+      return { property, generated: data };
+    },
+    onSuccess: async ({ property, generated }) => {
+      const supabase = createClient();
+
+      const platform = (generated.platform ?? "funda") as Platform;
+
+      // Insert advert into adverts table
+      const { data: advertRow, error: advertError } = await supabase
+        .from("adverts")
+        .insert({
+          property_id: property.id,
+          title: generated.title,
+          description: generated.description,
+          features: generated.features,
+          platform,
+        })
+        .select()
+        .single();
+
+      if (advertError) {
+        console.error("Failed to save advert:", advertError);
+      }
+
+      // Update property status to generated
+      const { error: updateError } = await supabase
+        .from("properties")
+        .update({ status: PropertyStatus.Generated })
+        .eq("id", property.id);
+
+      if (updateError) {
+        console.error("Failed to update property status:", updateError);
+      }
+
+      // Insert activity log entry
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        const { error: activityError } = await supabase
+          .from("activity_log")
+          .insert({
+            user_id: user.id,
+            type: "generated",
+            property_id: property.id,
+            property_address: property.address,
+            platform,
+          });
+
+        if (activityError) {
+          console.error("Failed to insert activity log:", activityError);
+        }
+      }
+
+      // Build advert object for UI
+      const resultAdvert: Advert = {
+        id: advertRow?.id ?? crypto.randomUUID(),
+        propertyId: property.id,
+        title: generated.title,
+        description: generated.description,
+        features: generated.features,
+        platform,
+        createdAt: advertRow?.created_at
+          ? new Date(advertRow.created_at)
+          : new Date(),
+      };
+
+      setAdvert(resultAdvert);
+
+      // Invalidate relevant caches
+      queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.properties.detail(property.id),
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["properties", "recent"],
+      });
+    },
+    onError: (err: Error) => {
+      setError(err.message);
+    },
+  });
+
+  const generate = useCallback(
+    async (property: Property) => {
+      setError(null);
+      setAdvert(null);
+      mutation.mutate(property);
+    },
+    [mutation]
+  );
 
   const reset = useCallback(() => {
     setAdvert(null);
     setError(null);
-    setIsLoading(false);
-  }, []);
+    mutation.reset();
+  }, [mutation]);
 
-  return { advert, isLoading, error, generate, reset };
+  return {
+    advert,
+    isLoading: mutation.isPending,
+    error,
+    generate,
+    reset,
+  };
 }

--- a/supabase/functions/generate-advert/index.ts
+++ b/supabase/functions/generate-advert/index.ts
@@ -1,0 +1,206 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.97.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+interface GenerateRequest {
+  propertyId: string;
+  address: string;
+  city: string;
+  price: number;
+  squareMeters: number;
+  rooms: number;
+  bedrooms: number;
+  bathrooms: number;
+  buildYear: number;
+  energyLabel: string;
+  platform?: string;
+  images?: string[];
+}
+
+const REQUIRED_FIELDS: (keyof GenerateRequest)[] = [
+  "propertyId",
+  "address",
+  "city",
+  "price",
+  "squareMeters",
+  "rooms",
+  "bedrooms",
+  "bathrooms",
+  "buildYear",
+  "energyLabel",
+];
+
+function buildPrompt(input: GenerateRequest): string {
+  return `Je bent een ervaren Nederlandse makelaar. Schrijf een professionele woningadvertentie in het Nederlands.
+
+Woninggegevens:
+- Adres: ${input.address}, ${input.city}
+- Prijs: EUR ${input.price}
+- Woonoppervlak: ${input.squareMeters} m2
+- Kamers: ${input.rooms} (waarvan ${input.bedrooms} slaapkamers, ${input.bathrooms} badkamers)
+- Bouwjaar: ${input.buildYear}
+- Energielabel: ${input.energyLabel}
+- Platform: ${input.platform ?? "funda"}
+
+Genereer een JSON-object met:
+- "title": Een pakkende titel (max 80 tekens)
+- "description": Een uitgebreide beschrijving (150-250 woorden)
+- "features": Een array van 5-7 kenmerken als korte zinnen
+
+Schrijf professioneel, enthousiast en specifiek. Gebruik geen generieke zinnen.
+Geef ALLEEN het JSON-object terug, geen andere tekst.`;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(
+      JSON.stringify({ error: "Method not allowed" }),
+      { status: 405, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+
+  try {
+    // Auth validation
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: "U bent niet ingelogd. Log opnieuw in." }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: "U bent niet ingelogd. Log opnieuw in." }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    // Input validation
+    const body: GenerateRequest = await req.json();
+
+    const missingFields = REQUIRED_FIELDS.filter(
+      (field) => body[field] === undefined || body[field] === null || body[field] === ""
+    );
+
+    if (missingFields.length > 0) {
+      return new Response(
+        JSON.stringify({
+          error: "Onvolledige woninggegevens. Controleer alle velden.",
+          missingFields,
+        }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    // Check Gemini API key
+    const geminiApiKey = Deno.env.get("GEMINI_API_KEY");
+    if (!geminiApiKey) {
+      console.error("GEMINI_API_KEY is not set");
+      return new Response(
+        JSON.stringify({ error: "Generatie mislukt, probeer het opnieuw." }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    // Call Gemini API
+    const prompt = buildPrompt(body);
+    const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${geminiApiKey}`;
+
+    const geminiResponse = await fetch(geminiUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: {
+          responseMimeType: "application/json",
+          responseSchema: {
+            type: "OBJECT",
+            properties: {
+              title: { type: "STRING" },
+              description: { type: "STRING" },
+              features: { type: "ARRAY", items: { type: "STRING" } },
+            },
+            required: ["title", "description", "features"],
+          },
+        },
+      }),
+    });
+
+    if (!geminiResponse.ok) {
+      const errorText = await geminiResponse.text();
+      console.error("Gemini API error:", geminiResponse.status, errorText);
+      return new Response(
+        JSON.stringify({ error: "Generatie mislukt, probeer het opnieuw." }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const geminiData = await geminiResponse.json();
+
+    // Parse response
+    const textContent =
+      geminiData?.candidates?.[0]?.content?.parts?.[0]?.text;
+
+    if (!textContent) {
+      console.error("No text content in Gemini response:", JSON.stringify(geminiData));
+      return new Response(
+        JSON.stringify({ error: "Generatie mislukt, probeer het opnieuw." }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    let parsed: { title: string; description: string; features: string[] };
+    try {
+      parsed = JSON.parse(textContent);
+    } catch {
+      console.error("Failed to parse Gemini JSON output:", textContent);
+      return new Response(
+        JSON.stringify({ error: "Generatie mislukt, probeer het opnieuw." }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    if (!parsed.title || !parsed.description || !Array.isArray(parsed.features)) {
+      console.error("Invalid Gemini response structure:", parsed);
+      return new Response(
+        JSON.stringify({ error: "Generatie mislukt, probeer het opnieuw." }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const platform = body.platform ?? "funda";
+
+    return new Response(
+      JSON.stringify({
+        title: parsed.title,
+        description: parsed.description,
+        features: parsed.features,
+        platform,
+      }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("Unexpected error:", err);
+    return new Response(
+      JSON.stringify({ error: "Generatie mislukt, probeer het opnieuw." }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
## Summary

- Add `supabase/functions/generate-advert/index.ts` Deno Edge Function that authenticates the user, validates property input, calls the Gemini 2.0 Flash API with a Dutch-language real-estate prompt, and returns structured JSON (title, description, features)
- Rewrite `src/hooks/use-generate.ts` to invoke the edge function via `supabase.functions.invoke`, persist the generated advert and activity log to the database, update property status, and invalidate React Query caches
- Exclude `supabase/functions` from the Next.js tsconfig to avoid Deno/Node type conflicts

## Changes

| File | What |
|------|------|
| `supabase/functions/generate-advert/index.ts` | New Deno Edge Function: auth check, input validation, Gemini API call, JSON schema enforcement |
| `src/hooks/use-generate.ts` | Replaced mock-AI call with `useMutation` that invokes the edge function, saves advert row, updates property status, logs activity, invalidates caches |
| `tsconfig.json` | Added `supabase/functions` to `exclude` array |

## Quality

- [x] `npm run lint` -- passes
- [x] `npx tsc --noEmit` -- passes
- [x] No new dependencies added (uses existing `@supabase/supabase-js` and `@tanstack/react-query`)

## Test plan

- [ ] Deploy edge function to Supabase and set `GEMINI_API_KEY` secret
- [ ] Navigate to a property upload page, fill in details, and click generate
- [ ] Verify the generated advert appears with title, description, and features in Dutch
- [ ] Check `adverts` table for new row with correct `property_id`
- [ ] Check `properties` table for status update to `generated`
- [ ] Check `activity_log` for new `generated` entry
- [ ] Test error cases: missing auth, missing fields, invalid Gemini key

Resolves BRO-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)