### PR TITLE
feat(BRO-15): configure React Query retry strategy

### DIFF
--- a/src/lib/query-provider.tsx
+++ b/src/lib/query-provider.tsx
@@ -5,12 +5,39 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
+import { classifyError, isRetryable, logQuery } from "@/lib/supabase/logger";
+
+function shouldRetry(failureCount: number, error: unknown): boolean {
+  if (failureCount >= 3) return false;
+  return isRetryable(error);
+}
+
+function retryDelay(attemptIndex: number): number {
+  return Math.min(1000 * 2 ** attemptIndex, 30000);
+}
+
+function handleMutationError(error: unknown): void {
+  const category = classifyError(error);
+  logQuery({
+    table: "unknown",
+    operation: "mutation",
+    duration_ms: 0,
+    status: "error",
+    error_category: category,
+    error_message: error instanceof Error ? error.message : String(error),
+  });
+}
 
 function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
         staleTime: 60 * 1000,
+        retry: shouldRetry,
+        retryDelay,
+      },
+      mutations: {
+        onError: handleMutationError,
       },
     },
   });


### PR DESCRIPTION
## Summary

- Configure TanStack React Query global retry strategy with intelligent error classification
- 4xx errors (auth, constraint, RLS) are not retried and surface immediately to the UI
- 5xx and network errors retry up to 3 times with exponential backoff (1s, 2s, 4s, capped at 30s)
- Mutation errors are logged via the structured logger from `src/lib/supabase/logger.ts`

## Changes

- **`src/lib/query-provider.tsx`**: Added `shouldRetry`, `retryDelay`, and `handleMutationError` functions; wired them into `QueryClient` `defaultOptions`

## Test plan

- [ ] Verify 4xx errors surface immediately without retry
- [ ] Verify 5xx errors retry up to 3 times with exponential backoff
- [ ] Verify mutation errors are logged via structured logger
- [ ] Verify lint and TypeScript checks pass

Closes BRO-15

Generated with [Claude Code](https://claude.com/claude-code)