### PR TITLE
feat(BRO-14): fix all broken Supabase queries and mutations

### DIFF
--- a/src/app/(auth)/registreren/page.tsx
+++ b/src/app/(auth)/registreren/page.tsx
@@ -106,10 +106,17 @@ export default function RegistrerenPage() {
       if (profileError) {
         // Retry once in case the trigger hasn't fired yet
         await new Promise((resolve) => setTimeout(resolve, 500));
-        await supabase
+        const { error: retryError } = await supabase
           .from("profiles")
           .update({ organization_id: org.id })
           .eq("id", user.id);
+
+        if (retryError) {
+          setError(
+            "Profiel koppelen mislukt. Neem contact op met support."
+          );
+          return;
+        }
       }
 
       router.push("/dashboard");

--- a/src/hooks/use-adverts.ts
+++ b/src/hooks/use-adverts.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
 import { queryKeys } from "@/lib/supabase/queries";
+import { logQuery } from "@/lib/supabase/logger";
 import { PropertyStatus } from "@/lib/types";
 import type { Advert, Platform } from "@/lib/types";
 
@@ -88,18 +89,31 @@ export function useSaveAdvert() {
         throw new Error(`Advertentie opslaan mislukt: ${error.message}`);
       }
 
-      // Create activity log entry
+      // Create activity log entry (non-critical: log but don't throw)
       const {
         data: { user },
       } = await supabase.auth.getUser();
       if (user) {
-        await supabase.from("activity_log").insert({
-          user_id: user.id,
-          type: "edited",
-          property_id: input.propertyId,
-          property_address: input.propertyAddress,
-          platform: input.platform,
-        });
+        const { error: activityError } = await supabase
+          .from("activity_log")
+          .insert({
+            user_id: user.id,
+            type: "edited",
+            property_id: input.propertyId,
+            property_address: input.propertyAddress,
+            platform: input.platform,
+          });
+        if (activityError) {
+          logQuery({
+            table: "activity_log",
+            operation: "insert",
+            duration_ms: 0,
+            error_category: "unknown",
+            error_message: activityError.message,
+            error_code: activityError.code,
+            status: "error",
+          });
+        }
       }
 
       return mapRowToAdvert(data as AdvertRow);
@@ -138,18 +152,31 @@ export function usePublishAdvert() {
         throw new Error(`Publiceren mislukt: ${updateError.message}`);
       }
 
-      // Create activity log entry
+      // Create activity log entry (non-critical: log but don't throw)
       const {
         data: { user },
       } = await supabase.auth.getUser();
       if (user) {
-        await supabase.from("activity_log").insert({
-          user_id: user.id,
-          type: "published",
-          property_id: input.propertyId,
-          property_address: input.propertyAddress,
-          platform: input.platform,
-        });
+        const { error: activityError } = await supabase
+          .from("activity_log")
+          .insert({
+            user_id: user.id,
+            type: "published",
+            property_id: input.propertyId,
+            property_address: input.propertyAddress,
+            platform: input.platform,
+          });
+        if (activityError) {
+          logQuery({
+            table: "activity_log",
+            operation: "insert",
+            duration_ms: 0,
+            error_category: "unknown",
+            error_message: activityError.message,
+            error_code: activityError.code,
+            status: "error",
+          });
+        }
       }
     },
     onSuccess: (_result, variables) => {
@@ -158,9 +185,6 @@ export function usePublishAdvert() {
       });
       queryClient.invalidateQueries({
         queryKey: queryKeys.properties.detail(variables.propertyId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["properties", "recent"],
       });
       queryClient.invalidateQueries({
         queryKey: queryKeys.activityFeed.all(10),

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -21,7 +21,13 @@ export function useAuth(): UseAuthReturn {
   useEffect(() => {
     const supabase = createClient();
 
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(({ data: { session }, error }) => {
+      if (error) {
+        setSession(null);
+        setUser(null);
+        setIsLoading(false);
+        return;
+      }
       setSession(session);
       setUser(session?.user ?? null);
       setIsLoading(false);
@@ -41,7 +47,10 @@ export function useAuth(): UseAuthReturn {
 
   async function signOut() {
     const supabase = createClient();
-    await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      throw error;
+    }
     router.push("/login");
   }
 

--- a/src/hooks/use-generate.ts
+++ b/src/hooks/use-generate.ts
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
 import { queryKeys } from "@/lib/supabase/queries";
+import { logQuery } from "@/lib/supabase/logger";
 import type { Property, Advert } from "@/lib/types";
 import { Platform, PropertyStatus } from "@/lib/types";
 
@@ -95,7 +96,9 @@ export function useGenerate(): UseGenerateReturn {
         .single();
 
       if (advertError) {
-        console.error("Failed to save advert:", advertError);
+        throw new Error(
+          `Advertentie opslaan mislukt: ${advertError.message}`
+        );
       }
 
       // Update property status to generated
@@ -105,10 +108,12 @@ export function useGenerate(): UseGenerateReturn {
         .eq("id", property.id);
 
       if (updateError) {
-        console.error("Failed to update property status:", updateError);
+        throw new Error(
+          `Woningsstatus bijwerken mislukt: ${updateError.message}`
+        );
       }
 
-      // Insert activity log entry
+      // Insert activity log entry (non-critical: log but don't throw)
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
         const { error: activityError } = await supabase
@@ -122,21 +127,27 @@ export function useGenerate(): UseGenerateReturn {
           });
 
         if (activityError) {
-          console.error("Failed to insert activity log:", activityError);
+          logQuery({
+            table: "activity_log",
+            operation: "insert",
+            duration_ms: 0,
+            error_category: "unknown",
+            error_message: activityError.message,
+            error_code: activityError.code,
+            status: "error",
+          });
         }
       }
 
-      // Build advert object for UI
+      // Build advert object for UI (advertRow guaranteed non-null after error check)
       const resultAdvert: Advert = {
-        id: advertRow?.id ?? crypto.randomUUID(),
+        id: advertRow!.id,
         propertyId: property.id,
         title: generated.title,
         description: generated.description,
         features: generated.features,
         platform,
-        createdAt: advertRow?.created_at
-          ? new Date(advertRow.created_at)
-          : new Date(),
+        createdAt: new Date(advertRow!.created_at),
       };
 
       setAdvert(resultAdvert);
@@ -147,7 +158,10 @@ export function useGenerate(): UseGenerateReturn {
         queryKey: queryKeys.properties.detail(property.id),
       });
       queryClient.invalidateQueries({
-        queryKey: ["properties", "recent"],
+        queryKey: queryKeys.adverts.byProperty(property.id),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.activityFeed.all(10),
       });
     },
     onError: (err: Error) => {

--- a/src/hooks/use-properties.ts
+++ b/src/hooks/use-properties.ts
@@ -50,12 +50,12 @@ export function useProperty(id: string | undefined) {
 export function useRecentProperties(limit = 3) {
   const supabase = createClient();
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.properties.recent(limit),
     queryFn: () => getRecentProperties(supabase, limit),
   });
 
-  return { properties: data ?? [], isLoading };
+  return { properties: data ?? [], isLoading, error };
 }
 
 export function useCreateProperty() {
@@ -66,9 +66,6 @@ export function useCreateProperty() {
     mutationFn: (data: CreatePropertyInput) => createProperty(supabase, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
-      queryClient.invalidateQueries({
-        queryKey: ["properties", "recent"],
-      });
     },
   });
 
@@ -84,9 +81,6 @@ export function useUpdateProperty() {
       updateProperty(supabase, id, data),
     onSuccess: (_result, variables) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
-      queryClient.invalidateQueries({
-        queryKey: ["properties", "recent"],
-      });
       queryClient.invalidateQueries({
         queryKey: queryKeys.properties.detail(variables.id),
       });
@@ -104,9 +98,6 @@ export function useDeleteProperty() {
     mutationFn: (id: string) => deleteProperty(supabase, id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
-      queryClient.invalidateQueries({
-        queryKey: ["properties", "recent"],
-      });
     },
   });
 

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -170,6 +170,7 @@ export async function getDashboardStats(
       .from("properties")
       .select("*", { count: "exact", head: true })
       .eq("status", "published")
+      .gte("created_at", previousMonth.start)
       .lt("created_at", previousMonth.end),
     supabase
       .from("adverts")
@@ -177,6 +178,22 @@ export async function getDashboardStats(
       .gte("created_at", previousMonth.start)
       .lt("created_at", previousMonth.end),
   ]);
+
+  // Check all query results for errors
+  const results = [
+    totalProps,
+    publishedProps,
+    advertsCurrent,
+    totalPropsPrev,
+    publishedPropsPrev,
+    advertsPrev,
+  ];
+  const firstError = results.find((r) => r.error);
+  if (firstError?.error) {
+    throw new Error(
+      `Dashboard statistieken ophalen mislukt: ${firstError.error.message}`
+    );
+  }
 
   const totalProperties = totalProps.count ?? 0;
   const published = publishedProps.count ?? 0;


### PR DESCRIPTION
## Summary

- **Fix unchecked Supabase errors**: All mutation and query results now properly check `.error` and throw or handle gracefully
- **Add structured error logging**: Activity log inserts use `logQuery()` instead of `console.error`
- **Fix stale query invalidation**: Replace hardcoded cache keys with centralized `queryKeys`
- **Fix dashboard stats query**: Add missing `.gte()` filter on previous-month published properties
- **Harden auth flows**: Handle `getSession` errors and `signOut` failures; fix registration retry

## Changes

| File | What changed |
|------|-------------|
| `src/lib/supabase/queries.ts` | Add `.gte()` filter for previous month stats; error check all parallel queries |
| `src/hooks/use-adverts.ts` | Check activity_log insert errors and log via `logQuery`; fix cache keys |
| `src/hooks/use-generate.ts` | Throw on failures instead of `console.error`; log activity errors; fix cache keys |
| `src/hooks/use-properties.ts` | Remove stale cache invalidation keys; expose `error` from `useRecentProperties` |
| `src/hooks/use-auth.ts` | Handle `getSession` error; throw on `signOut` failure |
| `src/app/(auth)/registreren/page.tsx` | Check retry profile-update error and show user-facing message |

## Test plan

- [ ] Verify dashboard stats load correctly
- [ ] Test advert save/publish flows
- [ ] Test AI generation error handling
- [ ] Verify registration and auth error handling

Closes BRO-14

---
Generated with [Claude Code](https://claude.com/claude-code)