### PR TITLE
feat(BRO-16): add toast notifications and inline error states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,11 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -10753,6 +10755,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -12585,6 +12597,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/src/app/(app)/advertentie/[id]/page.tsx
+++ b/src/app/(app)/advertentie/[id]/page.tsx
@@ -237,13 +237,36 @@ function AdvertEditorView({
 
 export default function AdvertentiePage() {
   const params = useParams<{ id: string }>();
-  const { property, isLoading: propertyLoading } = useProperty(params.id);
-  const { advert, isLoading: advertLoading } = useAdvert(params.id);
+  const { property, isLoading: propertyLoading, error: propertyError } = useProperty(params.id);
+  const { advert, isLoading: advertLoading, error: advertError } = useAdvert(params.id);
 
   const isLoading = propertyLoading || advertLoading;
 
   if (isLoading) {
     return <EditorSkeleton />;
+  }
+
+  // Fetch error
+  if (propertyError || advertError) {
+    return (
+      <div>
+        <Header title="Fout bij laden" />
+        <div className="px-[var(--space-8)] pb-[var(--space-8)]">
+          <div className="rounded-[var(--radius-md)] bg-[var(--destructive-subtle)] px-[var(--space-4)] py-[var(--space-3)] text-[14px] text-[var(--destructive)]">
+            {propertyError
+              ? "Woning kon niet worden geladen."
+              : "Advertentie kon niet worden geladen."}
+          </div>
+          <Link
+            href="/dashboard"
+            className="mt-[var(--space-4)] inline-flex items-center gap-[var(--space-2)] text-[14px] font-medium text-[var(--brand)] hover:text-[var(--brand-hover)]"
+          >
+            <ArrowLeft className="size-4" />
+            Terug naar dashboard
+          </Link>
+        </div>
+      </div>
+    );
   }
 
   // Property not found

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -49,9 +49,9 @@ function ActivityFeedSkeleton() {
 }
 
 export default function DashboardPage() {
-  const { properties } = useProperties();
-  const { stats, isLoading: statsLoading } = useDashboardStats();
-  const { activities, isLoading: feedLoading } = useActivityFeed(10);
+  const { properties, error: propertiesError } = useProperties();
+  const { stats, isLoading: statsLoading, error: statsError } = useDashboardStats();
+  const { activities, isLoading: feedLoading, error: feedError } = useActivityFeed(10);
   const { user } = useAuth();
 
   const firstName = user?.user_metadata?.full_name?.split(" ")[0]
@@ -75,6 +75,10 @@ export default function DashboardPage() {
               <StatCardSkeleton />
               <StatCardSkeleton />
             </>
+          ) : statsError ? (
+            <div className="col-span-full rounded-[var(--radius-md)] bg-[var(--destructive-subtle)] px-[var(--space-4)] py-[var(--space-3)] text-[14px] text-[var(--destructive)]">
+              Statistieken konden niet worden geladen.
+            </div>
           ) : (
             <>
               <StatCard
@@ -112,7 +116,11 @@ export default function DashboardPage() {
             <h2 className="text-[20px] font-semibold tracking-[-0.01em] text-[var(--ink)]">
               Woningen
             </h2>
-            {!statsLoading && stats?.totalProperties === 0 ? (
+            {propertiesError ? (
+              <div className="mt-[var(--space-4)] rounded-[var(--radius-md)] bg-[var(--destructive-subtle)] px-[var(--space-4)] py-[var(--space-3)] text-[14px] text-[var(--destructive)]">
+                Woningen konden niet worden geladen.
+              </div>
+            ) : !statsLoading && stats?.totalProperties === 0 ? (
               <p className="mt-[var(--space-4)] text-[14px] text-[var(--ink-secondary)]">
                 Nog geen woningen toegevoegd. Begin met het uploaden van een woning.
               </p>
@@ -129,6 +137,10 @@ export default function DashboardPage() {
           <div>
             {feedLoading ? (
               <ActivityFeedSkeleton />
+            ) : feedError ? (
+              <div className="rounded-[var(--radius-md)] bg-[var(--destructive-subtle)] px-[var(--space-4)] py-[var(--space-3)] text-[14px] text-[var(--destructive)]">
+                Activiteit kon niet worden geladen.
+              </div>
             ) : activities.length === 0 ? (
               <div
                 className="rounded-[var(--radius-md)] bg-[var(--surface-1)] p-[var(--space-5)]"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Plus_Jakarta_Sans } from "next/font/google";
 import "./globals.css";
 import QueryProvider from "@/lib/query-provider";
+import { Toaster } from "@/components/ui/sonner";
 
 const plusJakartaSans = Plus_Jakarta_Sans({
   variable: "--font-plus-jakarta-sans",
@@ -23,6 +24,7 @@ export default function RootLayout({
     <html lang="nl">
       <body className={`${plusJakartaSans.variable} antialiased`}>
         <QueryProvider>{children}</QueryProvider>
+        <Toaster />
       </body>
     </html>
   );

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/hooks/use-adverts.ts
+++ b/src/hooks/use-adverts.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { queryKeys } from "@/lib/supabase/queries";
 import { logQuery } from "@/lib/supabase/logger";
@@ -126,6 +127,11 @@ export function useSaveAdvert() {
         queryKey: queryKeys.activityFeed.all(10),
       });
     },
+    onError: () => {
+      toast.error("Advertentie opslaan mislukt", {
+        description: "Probeer het later opnieuw.",
+      });
+    },
   });
 
   return { saveAdvert: mutateAsync, isSaving: isPending, error };
@@ -188,6 +194,11 @@ export function usePublishAdvert() {
       });
       queryClient.invalidateQueries({
         queryKey: queryKeys.activityFeed.all(10),
+      });
+    },
+    onError: () => {
+      toast.error("Publiceren mislukt", {
+        description: "Probeer het later opnieuw.",
       });
     },
   });

--- a/src/hooks/use-properties.ts
+++ b/src/hooks/use-properties.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import {
   queryKeys,
@@ -67,6 +68,11 @@ export function useCreateProperty() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
     },
+    onError: () => {
+      toast.error("Woning aanmaken mislukt", {
+        description: "Probeer het later opnieuw.",
+      });
+    },
   });
 
   return { createProperty: mutateAsync, isCreating: isPending, error };
@@ -85,6 +91,11 @@ export function useUpdateProperty() {
         queryKey: queryKeys.properties.detail(variables.id),
       });
     },
+    onError: () => {
+      toast.error("Woning bijwerken mislukt", {
+        description: "Probeer het later opnieuw.",
+      });
+    },
   });
 
   return { updateProperty: mutateAsync, isUpdating: isPending, error };
@@ -98,6 +109,11 @@ export function useDeleteProperty() {
     mutationFn: (id: string) => deleteProperty(supabase, id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.properties.all });
+    },
+    onError: () => {
+      toast.error("Woning verwijderen mislukt", {
+        description: "Probeer het later opnieuw.",
+      });
     },
   });
 


### PR DESCRIPTION
## Summary

- Adds sonner toast library with a themed Toaster component in the root layout for global toast notifications
- Wires onError toast handlers to all mutation hooks (useSaveAdvert, usePublishAdvert, useCreateProperty, useUpdateProperty, useDeleteProperty) showing Dutch error messages
- Adds inline error banners to dashboard page (stats, properties list, activity feed) and advertentie editor page when data fetching fails

## Changes

- package.json / package-lock.json: Added sonner and next-themes dependencies
- src/components/ui/sonner.tsx: New shadcn/ui Toaster wrapper with themed styling and Lucide icons
- src/app/layout.tsx: Added Toaster to root layout
- src/hooks/use-adverts.ts: Added toast.error() in onError for save and publish mutations
- src/hooks/use-properties.ts: Added toast.error() in onError for create, update, and delete mutations
- src/app/(app)/dashboard/page.tsx: Inline error banners for stats, properties, and activity feed sections
- src/app/(app)/advertentie/[id]/page.tsx: Full-page error state with back-to-dashboard link

## Test plan

- [ ] Verify npm run build passes without errors
- [ ] Verify npm run lint passes without warnings
- [ ] Test toast notifications appear when mutations fail
- [ ] Test inline error banners show on dashboard when queries fail
- [ ] Test advertentie editor shows error state with back link when property/advert load fails

Closes BRO-16